### PR TITLE
Introduced configuredAuthServer that only requires .env  BASE_URL entry

### DIFF
--- a/packages/mcp-express/src/auth-wrapper.ts
+++ b/packages/mcp-express/src/auth-wrapper.ts
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2025, WSO2 LLC. (https://www.wso2.com).
+ * Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
  *
  * WSO2 LLC. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/packages/mcp-express/src/auth-wrapper.ts
+++ b/packages/mcp-express/src/auth-wrapper.ts
@@ -16,5 +16,20 @@
  * under the License.
  */
 
-export {McpAuthServer} from './McpAuthServer';
-export {configuredAuthServer} from './auth-wrapper.js';
+import {McpAuthServer} from './McpAuthServer.js';
+
+const PORT: string = process.env[`PORT`] || '3000';
+const {BASE_URL} = process.env;
+const MCP_RESOURCE: string = process.env['MCP_RESOURCE'] || `http://localhost:${PORT}/mcp`;
+
+if (!BASE_URL) {
+  throw new Error('BASE_URL is missing. Please set it in the .env file.');
+}
+
+const configuredAuthServer: McpAuthServer = new McpAuthServer({
+  baseUrl: BASE_URL,
+  issuer: `${BASE_URL}/oauth2/token`,
+  resource: MCP_RESOURCE,
+});
+
+export {configuredAuthServer};


### PR DESCRIPTION
<!-- Please do not remove any sections of the template. Add `N/A` if not applicable. -->

### Purpose

This introduces an easy configuration option for simple MCP server development.

No need to configure `McpAuthServer`; instead, only the following two changes are enough:

1. Import `configuredAuthServer`**
```ts
import { configuredAuthServer as auth } from '@asgardeo/mcp-express';
```

2. Set up BASE_URL in the .env file
```
BASE_URL=https://api.asgardeo.io/t/<your-org>
```

### Checklist

- [ X] Manual test round performed and verified.
- [ X] Documentation provided.


### Security checks
- [ X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines
- [ X] Ran ESLint and Prettier fixed any issues.
- [ X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets
